### PR TITLE
Add include for `root_top.conf` in the nginx.conf

### DIFF
--- a/docker/rootfs/etc/nginx/nginx.conf
+++ b/docker/rootfs/etc/nginx/nginx.conf
@@ -14,6 +14,9 @@ error_log /data/logs/fallback_error.log warn;
 # Includes files with directives to load dynamic modules.
 include /etc/nginx/modules/*.conf;
 
+# Custom
+include /data/nginx/custom/root_top[.]conf;
+
 events {
 	include /data/nginx/custom/events[.]conf;
 }


### PR DESCRIPTION
This pull request allows custom configuration of the root config in the top of the file. This can be used to load modules, which is not possible at the end of the config file. There is already a `http_top.conf`, so `root_top.conf` is a logical addition.

The PR NginxProxyManager/docker-nginx-full#28 added the geoip2 module as requested in Issue #46. But currently there is no way to actually load the modules if you cannot mount custom files to `/etc/nginx/modules/` like in the Truenas Scale NPM App.

Now you can just add a `root_top.conf` to the persistent mounted `/data/custom` folder and add the following content:
```
load_module /usr/lib/nginx/modules/ngx_http_geoip2_module.so;
load_module /usr/lib/nginx/modules/ngx_stream_geoip2_module.so;
```